### PR TITLE
Change nginx Installation Instructions

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -92,13 +92,22 @@ server {
     listen 80;
     server_name YOUR_SITE_DOMAIN;
     root YOUR_SITE_DIRECTORY/public;
+    index index.php;
     
     # Handle trailing slashes
-    rewrite ^(.*)/$ /$1 permanent;
+    rewrite ^/(.*)/$ /$1 permanent;
     
     # Create pretty URLs
-    location {
+    location / {
         try_files $uri $uri/ /index.php?$query_string;
+    }
+    
+    location ~ \.php$ {
+        include                 /etc/nginx/fastcgi_params;
+        fastcgi_index           index.php;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass            unix:/run/php/php7.0-fpm.sock;
     }
 }
 ```


### PR DESCRIPTION
The provided configuration for nginx is incorrect and slightly misleading. This should work as a standalone server directive with default configuration of PHP 7.0 on Ubuntu/Debian.

There were also some typo's regarding the location {} directive, it needs a path.

The redirect to handle the trailing slash results in a redirect loop, the regex needs to include the starting slash in order to ignore a root request (i.e. actually requesting "/" )
