### PR TITLE
Add better examples for ORM

### DIFF
--- a/orm-data-mappers.md
+++ b/orm-data-mappers.md
@@ -107,7 +107,7 @@ SQL data mappers use an SQL database for storage and querying.  `Opulence\Orm\Da
 
 <h4 id="sql-example">Example</h4>
 
-Let's take a look at an example of an SQL data mapper for WordPress posts:
+Let's take a look at an example of an SQL data mapper for Blog posts:
 
 ```php
 namespace Blog\Infrastructure\Persistence\Posts;


### PR DESCRIPTION
This examples show real-world scenario when project was created:

```
$ composer create-project opulence/project blog --prefer-dist
```

and than renamed

```
$ php apex app:rename Project Blog
```

It also free from `WordPress` brand (to not confuse users) and use hexagonal architecture principles for class namespaces.