### PR TITLE
Migrations documentation improvements for MySQL

### DIFF
--- a/database-migrations.md
+++ b/database-migrations.md
@@ -111,9 +111,9 @@ This will call all the `down()` methods in your executed migrations.  If you'd l
 
 <h2 id="using-mysql">Using MySQL</h2>
 
-The migrator will use the PostgreSQL database adapter by default. If you need MySQL configured, you need to define an environment variable called `DB_DRIVER` to point to your database adapter.
+The migrator will use the PostgreSQL database adapter by default. If you need MySQL configured, you need ensure that the `DB_DRIVER` environment variable is set correctly. If you're using `opulence/project`, then the relevant part setting is in `config/environment/.env.app.php`:
 
-```bash
-DB_DRIVER=Opulence\Databases\Adapters\Pdo\MySql\Driver
+```php
+Environment::setVar('DB_DRIVER', \Opulence\Databases\Adapters\Pdo\MySql\Driver::class);
 ```
 

--- a/database-migrations.md
+++ b/database-migrations.md
@@ -81,7 +81,7 @@ public function up() : void
 
 Migrations are discovered, run, and rolled back by an instance of `Opulence\Databases\Migrations\IMigrator` (`Migrator` comes built-in).  Migration classes are discovered by `FileMigrationFinder`, which recursively finds all classes that implement `IMigration` in a particular path or paths.  Those migrations are ordered by their creation dates.
 
-If you're using the <a href="https://github.com/opulencephp/Project" target="_blank">skeleton project</a>, you can configure the path to search for migration classes in _config/paths.php_ (defaults to _src/Application/Infrastructure/Databases/Migrations_).
+If you're using the <a href="https://github.com/opulencephp/Project" target="_blank">skeleton project</a>, you can configure the path to search for migration classes in _config/paths.php_ (defaults to _src/Infrastructure/Databases/Migrations_).
 
 <h2 id="running-migrations">Running Migrations</h2>
 
@@ -108,3 +108,12 @@ php apex migrations:down --number NUMBER_TO_ROLL_BACK
 ```
 
 This will call all the `down()` methods in your executed migrations.  If you'd like to roll back all your migrations, simply don't pass the `--number` option.  If you'd like to roll back migrations outside of the console, you can call `IMigrator::rollBackMigrations()`.
+
+<h2 id="using-mysql">Using MySQL</h2>
+
+The migrator will use the PostgreSQL database adapter by default. If you need MySQL configured, you need to define an environment variable called `DB_DRIVER` to point to your database adapter.
+
+```bash
+DB_DRIVER=Opulence\Databases\Adapters\Pdo\MySql\Driver
+```
+


### PR DESCRIPTION
- 1.1 fix for the migrations path
- Add section mentioning `DB_DRIVER`